### PR TITLE
Add support for more types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-sudo: required
 dist: trusty
 rust:
   - nightly-2018-03-18
@@ -10,22 +9,13 @@ before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH
 script:
-  - (cd wundergraph_derive && cargo rustc --no-default-features --features "lint" -- -Zno-trans)
-  - (cd wundergraph && cargo rustc --no-default-features --features "lint sqlite postgres extras" -- -Zno-trans)
-  - (cd wundergraph_example && cargo rustc --no-default-features --features "lint" -- -Zno-trans)
-    #matrix:
-    #  include:
-    #  - rust: nightly-2018-03-05
-    #    env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
-    #    script:
-    #    - (cd wundergraph_derive && cargo rustc --no-default-features --features "lint" -- -Zno-trans)
-    #    - (cd wundergraph && cargo rustc --no-default-features --features "lint sqlite postgres extras" -- -Zno-trans)
-    #    - (cd wundergraph_example && cargo rustc --no-default-features --features "lint" -- -Zno-trans)
-#  - rust: nightly-2018-03-06
-#    env: RUSTFMT=YESPLEASE
-#    script:
-#    - cargo install rustfmt-nightly --vers 0.3.7 --force
-#    - cargo fmt --all -- --write-mode=diff
+  - (cd wundergraph_derive && cargo rustc --no-default-features --features "lint $BACKEND" -- -Zno-trans)
+  - (cd wundergraph && cargo rustc --no-default-features --features "lint $BACKEND extras" -- -Zno-trans)
+  - (cd wundergraph_example && cargo rustc --no-default-features --features "lint $BACKEND" -- -Zno-trans)
+env:
+  matrix:
+    - BACKEND=sqlite
+    - BACKEND=postgres
 branches:
   only:
     - master

--- a/wundergraph/Cargo.toml
+++ b/wundergraph/Cargo.toml
@@ -16,6 +16,6 @@ chrono = { version = "0.4", optional = true }
 [features]
 default = ["sqlite", "postgres", "extras"]
 lint = ["clippy"]
-sqlite = ["diesel/sqlite"]
-postgres = ["diesel/postgres"]
+sqlite = ["diesel/sqlite", "wundergraph_derive/sqlite"]
+postgres = ["diesel/postgres", "wundergraph_derive/postgres"]
 extras = ["chrono", "uuid"]

--- a/wundergraph/src/filter/common_filter/eq.rs
+++ b/wundergraph/src/filter/common_filter/eq.rs
@@ -2,10 +2,11 @@ use filter::build_filter::BuildFilter;
 use filter::transformator::{FilterType, Transformator};
 
 use diesel::{BoxableExpression, Column, ExpressionMethods, SelectableExpression};
-use diesel::expression::{operators, AsExpression, NonAggregate};
+use diesel::expression::{operators, AsExpression, Expression, NonAggregate};
 use diesel::query_builder::QueryFragment;
 use diesel::backend::Backend;
-use diesel::sql_types::Bool;
+use diesel::sql_types::{Bool, HasSqlType};
+use diesel::serialize::ToSql;
 
 use juniper::{InputValue, ToInputValue};
 
@@ -30,9 +31,9 @@ where
 impl<C, T, DB> BuildFilter<DB> for Eq<T, C>
 where
     C: ExpressionMethods + NonAggregate + Column + QueryFragment<DB> + Default + 'static,
-    T: AsExpression<C::SqlType>,
+    T: AsExpression<C::SqlType> + ToSql<<C as Expression>::SqlType, DB>,
     T::Expression: NonAggregate + SelectableExpression<C::Table> + QueryFragment<DB> + 'static,
-    DB: Backend + 'static,
+    DB: Backend + HasSqlType<<C as Expression>::SqlType> + 'static,
     C::Table: 'static,
     operators::Eq<C, <T as AsExpression<C::SqlType>>::Expression>: SelectableExpression<C::Table, SqlType = Bool>,
 {

--- a/wundergraph/src/filter/common_filter/mod.rs
+++ b/wundergraph/src/filter/common_filter/mod.rs
@@ -8,8 +8,9 @@ use diesel::expression::{operators, AsExpression, NonAggregate, SelectableExpres
 use diesel::expression::array_comparison::{In, Many};
 use diesel::backend::Backend;
 use diesel::{BoxableExpression, Column};
-use diesel::sql_types::{Bool, SingleValue};
+use diesel::sql_types::{Bool, HasSqlType, SingleValue};
 use diesel::query_builder::QueryFragment;
+use diesel::serialize::ToSql;
 
 use juniper::{FromInputValue, GraphQLType, InputValue, LookAheadValue, Registry, ToInputValue};
 use juniper::meta::{Argument, MetaType};
@@ -222,13 +223,13 @@ where
 
 impl<T, C, DB> BuildFilter<DB> for FilterOption<T, C>
 where
-    DB: Backend + 'static,
+    DB: Backend + HasSqlType<C::SqlType> + 'static,
     T: FilterValue<C>,
     T::AdditionalFilter: BuildFilter<DB> + 'static,
     <T::AdditionalFilter as BuildFilter<DB>>::Ret: SelectableExpression<C::Table>
         + QueryFragment<DB>
         + 'static,
-    T::RawValue: AsExpression<C::SqlType> + 'static,
+    T::RawValue: AsExpression<C::SqlType> + ToSql<C::SqlType, DB> + 'static,
     <T::RawValue as AsExpression<C::SqlType>>::Expression: NonAggregate
         + SelectableExpression<C::Table>
         + QueryFragment<DB>

--- a/wundergraph/src/filter/string_filter/like.rs
+++ b/wundergraph/src/filter/string_filter/like.rs
@@ -5,7 +5,8 @@ use diesel::{BoxableExpression, Column, SelectableExpression, TextExpressionMeth
 use diesel::expression::{operators, AsExpression, NonAggregate};
 use diesel::query_builder::QueryFragment;
 use diesel::backend::Backend;
-use diesel::sql_types::Bool;
+use diesel::sql_types::{Bool, HasSqlType, Text};
+use diesel::serialize::ToSql;
 
 use juniper::{InputValue, ToInputValue};
 
@@ -32,7 +33,8 @@ where
         + SelectableExpression<C::Table>
         + QueryFragment<DB>
         + 'static,
-    DB: Backend + 'static,
+    DB: Backend + HasSqlType<Text> + 'static,
+    String: ToSql<Text, DB>,
     C::Table: 'static,
     operators::Like<C, <String as AsExpression<C::SqlType>>::Expression>: SelectableExpression<C::Table, SqlType = Bool>,
 {

--- a/wundergraph/src/mutations/delete.rs
+++ b/wundergraph/src/mutations/delete.rs
@@ -163,7 +163,7 @@ where
     T::FromClause: QueryFragment<Conn::Backend>,
     T::AllColumns: QueryFragment<Conn::Backend> + QueryId,
     Conn::Backend: HasSqlType<<T::AllColumns as Expression>::SqlType>,
-    R: LoadingHandler<Conn, Table = T, SqlType = T::SqlType>
+    R: LoadingHandler<Conn::Backend, Table = T, SqlType = T::SqlType>
         + GraphQLType<TypeInfo = (), Context = ()>,
     Filter<Q, <T::PrimaryKey as EqAll<Id>>::Output>: Copy + IntoUpdateTarget<Table = T> + LimitDsl,
     Limit<Filter<Q, <T::PrimaryKey as EqAll<Id>>::Output>>: QueryDsl

--- a/wundergraph/src/mutations/update.rs
+++ b/wundergraph/src/mutations/update.rs
@@ -31,7 +31,7 @@ where
           Tab::Query: FilterDsl<<Tab::PrimaryKey as EqAll<<&'a C as Identifiable>::Id>>::Output>,
     Filter<Tab::Query, <Tab::PrimaryKey as EqAll<<&'a C as Identifiable>::Id>>::Output>: LimitDsl,
     Limit<Filter<Tab::Query, <Tab::PrimaryKey as EqAll<<&'a C as Identifiable>::Id>>::Output>>: QueryDsl + BoxedDsl<'a, Conn::Backend, Output = BoxedSelectStatement<'a, Tab::SqlType, Tab, Conn::Backend>>,
-        R:  LoadingHandler<Conn, Table = Tab, SqlType = Tab::SqlType>
+        R:  LoadingHandler<Conn::Backend, Table = Tab, SqlType = Tab::SqlType>
         + GraphQLType<TypeInfo = (), Context = ()>,
     ;
 }
@@ -57,7 +57,7 @@ where
               Tab::Query: FilterDsl<<Tab::PrimaryKey as EqAll<<&'a C as Identifiable>::Id>>::Output>,
     Filter<Tab::Query, <Tab::PrimaryKey as EqAll<<&'a C as Identifiable>::Id>>::Output>: LimitDsl,
     Limit<Filter<Tab::Query, <Tab::PrimaryKey as EqAll<<&'a C as Identifiable>::Id>>::Output>>: QueryDsl + BoxedDsl<'a, Conn::Backend, Output = BoxedSelectStatement<'a, Tab::SqlType, Tab, Conn::Backend>>,
-        R:  LoadingHandler<Conn, Table = Tab, SqlType = Tab::SqlType>
+        R:  LoadingHandler<Conn::Backend, Table = Tab, SqlType = Tab::SqlType>
         + GraphQLType<TypeInfo = (), Context = ()>,
 
     {

--- a/wundergraph_derive/Cargo.toml
+++ b/wundergraph_derive/Cargo.toml
@@ -17,3 +17,5 @@ proc-macro = true
 default = []
 nightly = ["proc-macro2/nightly"]
 lint = ["clippy"]
+postgres = []
+sqlite = []

--- a/wundergraph_derive/src/filter.rs
+++ b/wundergraph_derive/src/filter.rs
@@ -85,6 +85,8 @@ pub fn derive(item: &syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod_with_reeport(
         dummy_mod,
         &quote! {
+            use self::wundergraph::diesel;
+
             #[derive(Nameable, BuildFilter, InnerFilter, Debug, Clone)]
             #[wundergraph(table_name = #table)]
             pub struct #filter_name {

--- a/wundergraph_example/Cargo.toml
+++ b/wundergraph_example/Cargo.toml
@@ -12,9 +12,14 @@ juniper_rocket = "=0.1.2"
 rocket = "0.3"
 rocket_codegen = "0.3"
 ordermap = "0.2"
-wundergraph = { path = "../wundergraph" }
 clippy = { version = "0.0.188", optional = true }
 
+[dependencies.wundergraph]
+path = "../wundergraph"
+default-features = false
+
 [features]
-default = []
+default = ["sqlite"]
 lint = ["clippy"]
+sqlite = ["wundergraph/sqlite"]
+postgres = ["wundergraph/postgres"]

--- a/wundergraph_example/src/main.rs
+++ b/wundergraph_example/src/main.rs
@@ -218,7 +218,10 @@ fn graphiql() -> content::Html<String> {
     juniper_rocket::graphiql_source("/graphql")
 }
 
-//type DBConnection = ::diesel::PgConnection;
+#[cfg(feature = "postgres")]
+type DBConnection = ::diesel::PgConnection;
+
+#[cfg(feature = "sqlite")]
 type DBConnection = ::diesel::SqliteConnection;
 
 #[get("/graphql?<request>")]

--- a/wundergraph_example/src/mutations.rs
+++ b/wundergraph_example/src/mutations.rs
@@ -71,10 +71,10 @@ pub struct NewAppearsIn {
 
 wundergraph_mutation_object! {
     Mutation {
-        Hero(key = i32, table = heros::table, insert = NewHero, update = HeroChangeset),
-        Species(key = i32, table = species::table, insert = NewSpecies, update = SpeciesChangeset),
-        HomeWorld(key = i32, table = home_worlds::table, insert = NewHomeWorld, update = HomeWorldChangeset),
-        Friend(key = (i32, i32 ), table = friends::table, insert = NewFriend),
-        AppearsIn(key = (i32, Episode), table = appears_in::table, insert = NewAppearsIn),
+        Hero(key = i32, insert = NewHero, update = HeroChangeset),
+        Species(key = i32, insert = NewSpecies, update = SpeciesChangeset),
+        HomeWorld(key = i32, insert = NewHomeWorld, update = HomeWorldChangeset),
+        Friend(key = (i32, i32 ), insert = NewFriend),
+        AppearsIn(key = (i32, Episode), insert = NewAppearsIn),
     }
 }


### PR DESCRIPTION
Now more types are supported in wundergraph. This commit adds support
for Uuid and NaiveDateTime, but also for self written types (like
those needed to use self written enums in postgres)
The down side of this approach is that we now generate impl's for
`LoadingHandler` and `BuildFilter` per supported backend and type and not one
generic impl per type anymore. This means this commit removes for
other backends than postgres and sqlite from `wundergraph_derive` (It
should be quite easy to add back specific backend, we just need to
generate an impl from them).
It is possible to use all supported backends together, but then only
types supported on all backends will be supported.