### PR TITLE
Fix problems with the example migrations

### DIFF
--- a/wundergraph_example/migrations/pg/2018-01-24-131925_setup/up.sql
+++ b/wundergraph_example/migrations/pg/2018-01-24-131925_setup/up.sql
@@ -20,7 +20,7 @@ CREATE TABLE heros(
 
 CREATE TABLE appears_in(
     hero_id INTEGER NOT NULL REFERENCES heros(id) ON DELETE CASCADE ON UPDATE RESTRICT,
-    episode INTEGER NOT NULL CHECK(episode IN (1,2,3)),
+    episode SMALLINT NOT NULL CHECK(episode IN (1,2,3)),
     PRIMARY KEY(hero_id, episode)
 );
 

--- a/wundergraph_example/migrations/sqlite/2018-01-24-131925_setup/up.sql
+++ b/wundergraph_example/migrations/sqlite/2018-01-24-131925_setup/up.sql
@@ -20,7 +20,7 @@ CREATE TABLE heros(
 
 CREATE TABLE appears_in(
     hero_id INTEGER NOT NULL REFERENCES heros(id) ON DELETE CASCADE ON UPDATE RESTRICT,
-    episode INTEGER NOT NULL CHECK(episode IN (1,2,3)),
+    episode SMALLINT NOT NULL CHECK(episode IN (1,2,3)),
     PRIMARY KEY(hero_id, episode)
 );
 


### PR DESCRIPTION
This fixes some problems with the example.
Diesel tries to run migrations directly from migrations/ and fails with this as the migrations are in subdirectories (pg, sqlite).
Also fixed a problem with the data type of episode (INTEGER -> SMALLINT), which caused problems with deserialization in postgres.
A new migration seemed overkill, so I fixed it in place.