### PR TITLE
Fix some CI errors

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -16,6 +16,12 @@ jobs:
         rust: ["1.35.0", "stable", "beta", "nightly"]
         backend: ["postgres", "sqlite"]
         os: [ubuntu-18.04, macos-latest, windows-lastest]
+        exclude:
+        # excludes postgres on OSX and Windows (unsupported in postgresql-action)
+        - os: macos-latest
+          backend: "postgres"
+        - os: windows-latest
+          backend: "postgres"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -17,11 +17,11 @@ jobs:
         backend: ["postgres", "sqlite"]
         os: [ubuntu-18.04, macos-latest, windows-lastest]
         exclude:
-        # excludes postgres on OSX and Windows (unsupported in postgresql-action)
-        - os: macos-latest
-          backend: "postgres"
-        - os: windows-latest
-          backend: "postgres"
+          # excludes postgres on OSX and Windows (unsupported in postgresql-action)
+          - os: macos-latest
+            backend: "postgres"
+          - os: windows-latest
+            backend: "postgres"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -6,7 +6,7 @@
 
 on: [pull_request]
 
-name: Quickstart
+name: Wundergraph CI
 
 jobs:
   check:
@@ -26,6 +26,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
+
+      - name: Setup System
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo apt-get update && sudo apt-get install -yy libsqlite3-dev libpq-dev
 
       - uses: harmon758/postgresql-action@v1
         if: matrix.backend == 'postgres'

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check
     strategy:
       matrix:
-        rust: ["1.35.0", "stable", "beta", "nightly"]
+        rust: ["1.38.0", "stable", "beta", "nightly"]
         backend: ["postgres", "sqlite"]
         os: [ubuntu-18.04, macos-latest, windows-lastest]
         exclude:

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check
     strategy:
       matrix:
-        rust: ["1.34.0", "stable", "beta", "nightly"]
+        rust: ["1.35.0", "stable", "beta", "nightly"]
         backend: ["postgres", "sqlite"]
         os: [ubuntu-18.04, macos-latest, windows-lastest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- bump minimum rust version to 1.35 and then 1.38 to have more stable features used by actix
- enable postegres on linux only (the action does not support now windows or osx)
  NOTE: windows is not excluded really...
- install missing libraries on linux

I think that's all what can be done touching the CI config only.
