### PR TITLE
Fix #24

### DIFF
--- a/wundergraph_example/src/mutations.rs
+++ b/wundergraph_example/src/mutations.rs
@@ -76,7 +76,7 @@ wundergraph::mutation_object! {
         Hero(insert = NewHero, update = HeroChangeset,),
         Species(insert = NewSpecies, update = SpeciesChangeset,),
         HomeWorld(insert = NewHomeWorld, update = HomeWorldChangeset,),
-        Friend( insert = NewFriend,),
+        Friend( insert = NewFriend, update = false),
         AppearsIn(insert = NewAppearsIn, ),
     }
 }


### PR DESCRIPTION
Turns out it was not implemented at all. This commit adds support for
explicitly disabling insert and update mutations in the
`wundergraph::mutation_object!`, by adding more macro parsing steps at
the right places